### PR TITLE
Add GitHub Skills activity to registration system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Registration closes this week - Schedule TBA",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the missing **GitHub Skills** activity to the extracurricular activities registration system, addressing the urgent request from issue #6.

## Changes
- Added "GitHub Skills" to the activities dictionary in `src/app.py`
- Activity description highlights it's part of the GitHub Certifications program
- Set max participants to 25 students
- Noted urgent registration deadline (closes this week)

## Context
As announced by the principal in the school assembly, this partnership with GitHub will teach students practical coding and collaboration skills. The activity was announced but missing from the registration website, preventing students from signing up.

## Impact
- ✅ Students can now register for GitHub Skills
- ✅ Addresses time-sensitive registration deadline
- ✅ Supports GitHub Certifications program for college applications

Fixes #6

---

**Note:** This is a time-sensitive fix as registration closes at the end of this week per the principal's announcement.